### PR TITLE
Solved crash rotating device and duplicated fragment in Splash

### DIFF
--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/models/Repository.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/models/Repository.java
@@ -1,5 +1,8 @@
 package com.github.globant.githubsubscribers.commons.models;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -8,7 +11,7 @@ import com.google.gson.annotations.SerializedName;
  * @author juan.herrera
  * @since 31/08/2016
  */
-public class Repository {
+public class Repository implements Parcelable {
 
     private String id;
     private String name;
@@ -23,6 +26,25 @@ public class Repository {
         this.fullName = fullName;
         this.htmlUrl = htmlUrl;
     }
+
+    protected Repository(Parcel in) {
+        id = in.readString();
+        name = in.readString();
+        fullName = in.readString();
+        htmlUrl = in.readString();
+    }
+
+    public static final Creator<Repository> CREATOR = new Creator<Repository>() {
+        @Override
+        public Repository createFromParcel(Parcel in) {
+            return new Repository(in);
+        }
+
+        @Override
+        public Repository[] newArray(int size) {
+            return new Repository[size];
+        }
+    };
 
     public String getId() {
         return id;
@@ -40,4 +62,16 @@ public class Repository {
         return htmlUrl;
     }
 
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(id);
+        dest.writeString(name);
+        dest.writeString(fullName);
+        dest.writeString(htmlUrl);
+    }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/models/Subscriber.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/models/Subscriber.java
@@ -1,5 +1,8 @@
 package com.github.globant.githubsubscribers.commons.models;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.lang.reflect.Field;
@@ -11,7 +14,7 @@ import java.lang.reflect.Field;
  * @author juan.herrera
  * @since 19/08/2016
  */
-public class Subscriber {
+public class Subscriber implements Parcelable{
 
     private final String login;
     private final String id;
@@ -23,6 +26,24 @@ public class Subscriber {
         this.id = id;
         this.avataUrl = avataUrl;
     }
+
+    protected Subscriber(Parcel in) {
+        login = in.readString();
+        id = in.readString();
+        avataUrl = in.readString();
+    }
+
+    public static final Creator<Subscriber> CREATOR = new Creator<Subscriber>() {
+        @Override
+        public Subscriber createFromParcel(Parcel in) {
+            return new Subscriber(in);
+        }
+
+        @Override
+        public Subscriber[] newArray(int size) {
+            return new Subscriber[size];
+        }
+    };
 
     public String getLogin() {
         return login;
@@ -61,4 +82,15 @@ public class Subscriber {
         return result.toString();
     }
 
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(login);
+        dest.writeString(id);
+        dest.writeString(avataUrl);
+    }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/models/User.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/models/User.java
@@ -1,5 +1,8 @@
 package com.github.globant.githubsubscribers.commons.models;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -8,7 +11,7 @@ import com.google.gson.annotations.SerializedName;
  * @author juan.herrera
  * @since 30/08/2016
  */
-public class User {
+public class User implements Parcelable {
     private String login;
     private int id;
     @SerializedName("avatar_url")
@@ -36,6 +39,31 @@ public class User {
         this.followers = followers;
         this.following = following;
     }
+
+    protected User(Parcel in) {
+        login = in.readString();
+        id = in.readInt();
+        avatarUrl = in.readString();
+        htmlUrl = in.readString();
+        name = in.readString();
+        company = in.readString();
+        location = in.readString();
+        publicRepos = in.readInt();
+        followers = in.readInt();
+        following = in.readInt();
+    }
+
+    public static final Creator<User> CREATOR = new Creator<User>() {
+        @Override
+        public User createFromParcel(Parcel in) {
+            return new User(in);
+        }
+
+        @Override
+        public User[] newArray(int size) {
+            return new User[size];
+        }
+    };
 
     public String getLogin() {
         return login;
@@ -75,5 +103,24 @@ public class User {
 
     public int getFollowing() {
         return following;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(login);
+        dest.writeInt(id);
+        dest.writeString(avatarUrl);
+        dest.writeString(htmlUrl);
+        dest.writeString(name);
+        dest.writeString(company);
+        dest.writeString(location);
+        dest.writeInt(publicRepos);
+        dest.writeInt(followers);
+        dest.writeInt(following);
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
@@ -3,6 +3,7 @@ package com.github.globant.githubsubscribers.commons.utils;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 /**
@@ -16,6 +17,12 @@ public class Utils {
     public static void debugLog(String msg) {
         if (Constants.DEBUG_LOGS) {
             Log.i(Constants.DEBUG_PREFIX, msg);
+        }
+    }
+
+    public static void hideBar(AppCompatActivity activity) {
+        if (activity.getSupportActionBar() != null) {
+            activity.getSupportActionBar().hide();
         }
     }
 

--- a/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
@@ -8,6 +8,7 @@ import android.widget.ImageView;
 
 import com.github.globant.githubsubscribers.R;
 import com.github.globant.githubsubscribers.commons.utils.Constants;
+import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.main.MainActivity;
 
 /**
@@ -23,8 +24,11 @@ public class SplashActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
-        startAnimation();
-        startTimer();
+        Utils.hideBar(this);
+        if (savedInstanceState == null) {
+            startAnimation();
+            startTimer();
+        }
     }
 
     /**

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractor.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractor.java
@@ -12,6 +12,10 @@ import java.util.List;
  * @since 30/08/2016
  */
 public interface SubscriberDetailInteractor {
+    void onCancelRequestUser();
+
+    void onCancelRequestRepository();
+
     interface OnFinishedListener {
         void onFinishedUser(User userItem);
         void onFailureUser(String errorMessage);

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
@@ -19,10 +19,13 @@ import retrofit2.Response;
  * @since 30/08/2016
  */
 public class SubscriberDetailInteractorImpl implements SubscriberDetailInteractor {
+    private Call<User> callUser;
+    private Call<List<Repository>> callRepositories;
+
     @Override
     public void getUserData(String userName, final OnFinishedListener listener) {
-        Call<User> call = ApiClientGithub.getApiService().getSubscriberUser(userName);
-        call.enqueue(new Callback<User>() {
+        callUser = ApiClientGithub.getApiService().getSubscriberUser(userName);
+        callUser.enqueue(new Callback<User>() {
             @Override
             public void onResponse(Call<User> call, Response<User> response) {
                 if (response.isSuccessful()) {
@@ -42,8 +45,8 @@ public class SubscriberDetailInteractorImpl implements SubscriberDetailInteracto
 
     @Override
     public void getUserRepositoryData(String userName, final OnFinishedListener listener) {
-        Call<List<Repository>> call = ApiClientGithub.getApiService().getUserRepositories(userName);
-        call.enqueue(new Callback<List<Repository>>() {
+        callRepositories = ApiClientGithub.getApiService().getUserRepositories(userName);
+        callRepositories.enqueue(new Callback<List<Repository>>() {
             @Override
             public void onResponse(Call<List<Repository>> call, Response<List<Repository>> response) {
                 if (response.isSuccessful()) {
@@ -60,5 +63,19 @@ public class SubscriberDetailInteractorImpl implements SubscriberDetailInteracto
                 listener.onFailureRepository(t.getMessage());
             }
         });
+    }
+
+    @Override
+    public void onCancelRequestUser() {
+        if (callUser != null && callUser.isExecuted()) {
+            callUser.cancel();
+        }
+    }
+
+    @Override
+    public void onCancelRequestRepository() {
+        if (callRepositories != null && callRepositories.isExecuted()) {
+            callRepositories.cancel();
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenter.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenter.java
@@ -1,5 +1,10 @@
 package com.github.globant.githubsubscribers.subscribersdetail.presenter;
 
+import com.github.globant.githubsubscribers.commons.models.Repository;
+import com.github.globant.githubsubscribers.commons.models.User;
+
+import java.util.List;
+
 /**
  * Interface SubscriberDetailPresenter that represents the presenter class to communicate the Activity
  * class(view) and Interactor class(User Model).
@@ -14,4 +19,8 @@ public interface SubscriberDetailPresenter {
     void getUser(String userName);
 
     void getRepositoryList(String userName);
+
+    User getUserData();
+
+    List<Repository> getRepositoryListData();
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
@@ -7,6 +7,7 @@ import com.github.globant.githubsubscribers.subscribersdetail.interactor.Subscri
 import com.github.globant.githubsubscribers.subscribersdetail.interactor.SubscriberDetailInteractorImpl;
 import com.github.globant.githubsubscribers.subscribersdetail.view.SubscriberDetailView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -20,34 +21,53 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
 
     private SubscriberDetailView view;
     private SubscriberDetailInteractor interactor;
+    private User userData;
+    private List<Repository> repositoryListData;
 
     public SubscriberDetailPresenterImpl(SubscriberDetailView view) {
         this.view = view;
         this.interactor = new SubscriberDetailInteractorImpl();
+        this.repositoryListData = new ArrayList<>();
+    }
+
+    public SubscriberDetailPresenterImpl(SubscriberDetailView view, User userData, List<Repository> repositoryListData) {
+        this.view = view;
+        this.interactor = new SubscriberDetailInteractorImpl();
+        this.repositoryListData = repositoryListData;
+        this.userData = userData;
     }
 
     public void onFinishedUser(User userItem) {
-        view.showSubscriberDetails(userItem);
+        userData = userItem;
+        view.showSubscriberDetails(userData);
     }
 
     @Override
     public void onFailureUser(String errorMessage) {
-        view.showUserError();
+        if(view != null) {
+            view.showUserError();
+        }
     }
 
     @Override
     public void onFinishedRepository(List<Repository> repositoryList) {
-        view.showSubscriberUserRepositories(repositoryList);
+        repositoryListData.clear();
+        repositoryListData.addAll(repositoryList);
+        view.showSubscriberUserRepositories(repositoryListData);
     }
 
     @Override
     public void onFailureRepository(String errorMessage) {
-        view.showRepositoryError();
+        if(view != null) {
+            view.showRepositoryError();
+        }
     }
 
     @Override
     public void onDestroy() {
         view = null;
+        interactor.onCancelRequestUser();
+        interactor.onCancelRequestRepository();
     }
 
     @Override
@@ -58,5 +78,13 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
     @Override
     public void getRepositoryList(String userName) {
         interactor.getUserRepositoryData(userName, this);
+    }
+
+    public User getUserData() {
+        return userData;
+    }
+
+    public List<Repository> getRepositoryListData() {
+        return repositoryListData;
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
@@ -1,6 +1,7 @@
 package com.github.globant.githubsubscribers.subscribersdetail.view;
 
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -19,6 +20,7 @@ import com.github.globant.githubsubscribers.subscribersdetail.presenter.Subscrib
 import com.github.globant.githubsubscribers.subscribersdetail.presenter.SubscriberDetailPresenterImpl;
 import com.squareup.picasso.Picasso;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -29,8 +31,12 @@ import java.util.List;
  */
 public class SubscriberDetailFragment extends Fragment implements SubscriberDetailView, RepositoryAdapter.OnRepositoryItemClickListener, View.OnClickListener {
 
-    private static final String ARG_USERNAME = "ARG_USERNAME";
+    private final static String PRESENTER_USER_DATA = "PRESENTER_USER_DATA";
+    private final static String PRESENTER_REPO_LIST_DATA = "PRESENTER_REPO_LIST_DATA";
+    private final static String ARG_USERNAME = "ARG_USERNAME";
+    private final static String HTML_URL = "HTML_URL";
     private String userNameParam;
+    private String profileHtmlUrl;
 
     private ImageView profileImage;
     private TextView profileFullName;
@@ -40,19 +46,22 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     private TextView profileFollowersCounter;
     private TextView profileFollowingCounter;
     private TextView profileReposCounter;
-    private String profileHtmlUrl;
     private RepositoryAdapter repositoriesAdapter;
-    private View viewFragment;
-
     private SubscriberDetailPresenter presenter;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        loadArgs();
-        if (savedInstanceState == null) {
-            setRetainInstance(true);
-            repositoriesAdapter = new RepositoryAdapter();
+
+        repositoriesAdapter = new RepositoryAdapter();
+        if (savedInstanceState != null) {
+            User userData = savedInstanceState.getParcelable(PRESENTER_USER_DATA);
+            List<Repository> repositoryListData = savedInstanceState.getParcelableArrayList(PRESENTER_REPO_LIST_DATA);
+            userNameParam = savedInstanceState.getString(ARG_USERNAME);
+            profileHtmlUrl = savedInstanceState.getString(HTML_URL);
+            presenter = new SubscriberDetailPresenterImpl(this, userData, repositoryListData);
+        } else {
+            loadArgs();
             presenter = new SubscriberDetailPresenterImpl(this);
         }
     }
@@ -74,32 +83,60 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        if (savedInstanceState == null) {
-            viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
+        View viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
+        return viewFragment;
+    }
 
-            profileImage = (ImageView) viewFragment.findViewById(R.id.img_avatar_subscriber_detail);
-            profileFullName = (TextView) viewFragment.findViewById(R.id.txt_full_name_subscriber_detail);
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (getView() != null) {
+            profileImage = (ImageView) getView().findViewById(R.id.img_avatar_subscriber_detail);
+            profileFullName = (TextView) getView().findViewById(R.id.txt_full_name_subscriber_detail);
             profileFullName.setOnClickListener(this);
-            profileUserName = (TextView) viewFragment.findViewById(R.id.txt_user_name_subscriber_detail);
-            profileCompany = (TextView) viewFragment.findViewById(R.id.txt_company_subscriber_detail);
-            profileLocation = (TextView) viewFragment.findViewById(R.id.txt_location_subscriber_detail);
-            profileFollowingCounter = (TextView) viewFragment.findViewById(R.id.txt_following_counter_subscriber_detail);
-            profileFollowersCounter = (TextView) viewFragment.findViewById(R.id.txt_followers_counter_subscriber_detail);
-            profileReposCounter = (TextView) viewFragment.findViewById(R.id.txt_repos_counter_subscriber_detail);
+            profileUserName = (TextView) getView().findViewById(R.id.txt_user_name_subscriber_detail);
+            profileCompany = (TextView) getView().findViewById(R.id.txt_company_subscriber_detail);
+            profileLocation = (TextView) getView().findViewById(R.id.txt_location_subscriber_detail);
+            profileFollowingCounter = (TextView) getView().findViewById(R.id.txt_following_counter_subscriber_detail);
+            profileFollowersCounter = (TextView) getView().findViewById(R.id.txt_followers_counter_subscriber_detail);
+            profileReposCounter = (TextView) getView().findViewById(R.id.txt_repos_counter_subscriber_detail);
 
-            RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.list_repositories);
+            RecyclerView recyclerViewSubscribers = (RecyclerView) getView().findViewById(R.id.list_repositories);
             recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
             recyclerViewSubscribers.setAdapter(repositoriesAdapter);
             repositoriesAdapter.setClickListener(this);
         }
-        return viewFragment;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        ArrayList<Repository> repositoryListData = (ArrayList<Repository>) presenter.getRepositoryListData();
+        outState.putParcelableArrayList(PRESENTER_REPO_LIST_DATA, repositoryListData);
+
+        User userData = presenter.getUserData();
+        outState.putParcelable(PRESENTER_USER_DATA, userData);
+
+        outState.putString(ARG_USERNAME, userNameParam);
+        outState.putString(HTML_URL, profileHtmlUrl);
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        presenter.getUser(userNameParam);
-        presenter.getRepositoryList(userNameParam);
+        User userData = presenter.getUserData();
+        if (userData != null) {
+            showSubscriberDetails(userData);
+        } else {
+            presenter.getUser(userNameParam);
+        }
+
+        ArrayList<Repository> repositoryListData = (ArrayList<Repository>) presenter.getRepositoryListData();
+        if (repositoryListData != null && !repositoryListData.isEmpty()) {
+            showSubscriberUserRepositories(repositoryListData);
+        } else {
+            presenter.getRepositoryList(userNameParam);
+        }
     }
 
     public void onDestroy() {

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
@@ -42,6 +42,7 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     private TextView profileReposCounter;
     private String profileHtmlUrl;
     private RepositoryAdapter repositoriesAdapter;
+    private View viewFragment;
 
     private SubscriberDetailPresenter presenter;
 
@@ -49,7 +50,11 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         loadArgs();
-        repositoriesAdapter = new RepositoryAdapter();
+        if (savedInstanceState == null) {
+            setRetainInstance(true);
+            repositoriesAdapter = new RepositoryAdapter();
+            presenter = new SubscriberDetailPresenterImpl(this);
+        }
     }
 
     public static SubscriberDetailFragment newInstance(String userName) {
@@ -69,23 +74,24 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
-        presenter = new SubscriberDetailPresenterImpl(this);
+        if (savedInstanceState == null) {
+            viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
 
-        profileImage = (ImageView) viewFragment.findViewById(R.id.img_avatar_subscriber_detail);
-        profileFullName = (TextView) viewFragment.findViewById(R.id.txt_full_name_subscriber_detail);
-        profileFullName.setOnClickListener(this);
-        profileUserName = (TextView) viewFragment.findViewById(R.id.txt_user_name_subscriber_detail);
-        profileCompany = (TextView) viewFragment.findViewById(R.id.txt_company_subscriber_detail);
-        profileLocation = (TextView) viewFragment.findViewById(R.id.txt_location_subscriber_detail);
-        profileFollowingCounter = (TextView) viewFragment.findViewById(R.id.txt_following_counter_subscriber_detail);
-        profileFollowersCounter = (TextView) viewFragment.findViewById(R.id.txt_followers_counter_subscriber_detail);
-        profileReposCounter = (TextView) viewFragment.findViewById(R.id.txt_repos_counter_subscriber_detail);
+            profileImage = (ImageView) viewFragment.findViewById(R.id.img_avatar_subscriber_detail);
+            profileFullName = (TextView) viewFragment.findViewById(R.id.txt_full_name_subscriber_detail);
+            profileFullName.setOnClickListener(this);
+            profileUserName = (TextView) viewFragment.findViewById(R.id.txt_user_name_subscriber_detail);
+            profileCompany = (TextView) viewFragment.findViewById(R.id.txt_company_subscriber_detail);
+            profileLocation = (TextView) viewFragment.findViewById(R.id.txt_location_subscriber_detail);
+            profileFollowingCounter = (TextView) viewFragment.findViewById(R.id.txt_following_counter_subscriber_detail);
+            profileFollowersCounter = (TextView) viewFragment.findViewById(R.id.txt_followers_counter_subscriber_detail);
+            profileReposCounter = (TextView) viewFragment.findViewById(R.id.txt_repos_counter_subscriber_detail);
 
-        RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.list_repositories);
-        recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
-        recyclerViewSubscribers.setAdapter(repositoriesAdapter);
-        repositoriesAdapter.setClickListener(this);
+            RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.list_repositories);
+            recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
+            recyclerViewSubscribers.setAdapter(repositoriesAdapter);
+            repositoriesAdapter.setClickListener(this);
+        }
         return viewFragment;
     }
 
@@ -103,13 +109,11 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
 
     @Override
     public void showUserError() {
-        //TODO Manage error messages
         Toast.makeText(getContext(), R.string.api_client_error, Toast.LENGTH_LONG).show();
     }
 
     @Override
     public void showRepositoryError() {
-        //TODO Manage error messages
         Toast.makeText(getContext(), R.string.api_client_error, Toast.LENGTH_LONG).show();
     }
 

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractor.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractor.java
@@ -14,9 +14,11 @@ import java.util.List;
 public interface SubscribersListInteractor {
     interface OnFinishedListener {
         void onResponse(List<Subscriber> listItems);
+
         void onFailure(String errorMessage);
     }
 
     void getSubscribersDataList(OnFinishedListener listener);
 
+    void onCancelRequest();
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
@@ -43,7 +43,7 @@ public class SubscribersListInteractorImpl implements SubscribersListInteractor 
 
     @Override
     public void onCancelRequest() {
-        if(call != null && call.isExecuted()){
+        if (call != null && call.isExecuted()) {
             call.cancel();
         }
     }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
@@ -3,7 +3,6 @@ package com.github.globant.githubsubscribers.subscriberslist.interactor;
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
 import com.github.globant.githubsubscribers.commons.utils.ApiClientGithub;
 import com.github.globant.githubsubscribers.commons.utils.Constants;
-import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractor;
 
 import java.util.List;
 
@@ -19,17 +18,18 @@ import retrofit2.Response;
  * @since 19/08/2016
  */
 public class SubscribersListInteractorImpl implements SubscribersListInteractor {
+    Call<List<Subscriber>> call;
+
     @Override
     public void getSubscribersDataList(final OnFinishedListener listener) {
-        Call<List<Subscriber>> call = ApiClientGithub.getApiService().getSubscribers();
+        call = ApiClientGithub.getApiService().getSubscribers();
         call.enqueue(new Callback<List<Subscriber>>() {
             @Override
             public void onResponse(Call<List<Subscriber>> call, Response<List<Subscriber>> response) {
-                if(response.isSuccessful()){
+                if (response.isSuccessful()) {
                     List<Subscriber> userList = response.body();
                     listener.onResponse(userList);
-                }
-                else{
+                } else {
                     listener.onFailure(Constants.MESSAGE_FAILED_SERVICE);
                 }
             }
@@ -39,5 +39,12 @@ public class SubscribersListInteractorImpl implements SubscribersListInteractor 
                 listener.onFailure(t.getMessage());
             }
         });
+    }
+
+    @Override
+    public void onCancelRequest() {
+        if(call != null && call.isExecuted()){
+            call.cancel();
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenter.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenter.java
@@ -1,5 +1,9 @@
 package com.github.globant.githubsubscribers.subscriberslist.presenter;
 
+import com.github.globant.githubsubscribers.commons.models.Subscriber;
+
+import java.util.List;
+
 /**
  * Interface SubscribersListPresenter that represents the presenter class to communicate the Activity class(view) and Interactor class(Model).
  *
@@ -11,4 +15,6 @@ public interface SubscribersListPresenter {
     void onDestroy();
 
     void getSubscribersList();
+
+    List<Subscriber> getSubscribersListData();
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
@@ -1,10 +1,12 @@
 package com.github.globant.githubsubscribers.subscriberslist.presenter;
 
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
+import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractor;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractorImpl;
 import com.github.globant.githubsubscribers.subscriberslist.view.SubscribersListView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -18,15 +20,24 @@ public class SubscribersListPresenterImpl implements SubscribersListPresenter, S
 
     private SubscribersListView view;
     private SubscribersListInteractor interactor;
+    private List<Subscriber> subscribersListData;
 
     public SubscribersListPresenterImpl(SubscribersListView view) {
         this.view = view;
         this.interactor = new SubscribersListInteractorImpl();
+        this.subscribersListData = new ArrayList<>();
+    }
+
+    public SubscribersListPresenterImpl(SubscribersListView view, List<Subscriber> subscribersListData) {
+        this.view = view;
+        this.interactor = new SubscribersListInteractorImpl();
+        this.subscribersListData = subscribersListData;
     }
 
     @Override
     public void onDestroy() {
         view = null;
+        interactor.onCancelRequest();
     }
 
     @Override
@@ -36,12 +47,20 @@ public class SubscribersListPresenterImpl implements SubscribersListPresenter, S
 
     @Override
     public void onResponse(List<Subscriber> listItems) {
-        view.showSubscribersList(listItems);
+        subscribersListData.clear();
+        subscribersListData.addAll(listItems);
+        view.showSubscribersList(subscribersListData);
+    }
+
+    public List<Subscriber> getSubscribersListData() {
+        return subscribersListData;
     }
 
     @Override
     public void onFailure(String errorMessage) {
         //TODO: Manage message errors
-        view.showSubscribersError();
+        if (view != null) {
+            view.showSubscribersError();
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersAdapter.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersAdapter.java
@@ -78,10 +78,6 @@ public class SubscribersAdapter extends RecyclerView.Adapter<SubscribersAdapter.
             Picasso.with(image.getContext()).load(item.getAvataUrl()).into(image);
         }
 
-        public String getUserName() {
-            return text.getText().toString();
-        }
-
         @Override
         public void onClick(View view) {
             if (clickListener != null) {

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
@@ -31,26 +31,34 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
     private SubscribersListPresenter presenter;
     private SubscribersAdapter subscribersAdapter;
     private SwipeRefreshLayout swipeLayout;
+    private View viewFragment;
 
     private OnFragmentInteractionListener mListener;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        subscribersAdapter = new SubscribersAdapter();
+        if (savedInstanceState == null) {
+            setRetainInstance(true);
+            subscribersAdapter = new SubscribersAdapter();
+            presenter = new SubscribersListPresenterImpl(this);
+        }
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View viewFragment = inflater.inflate(R.layout.fragment_subscribers_list, container, false);
-        swipeLayout = (SwipeRefreshLayout) viewFragment.findViewById(R.id.swipe_layout);
-        swipeLayout.setOnRefreshListener(this);
-        presenter = new SubscribersListPresenterImpl(this);
-        RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.recycler_view_subscribers);
-        recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
-        recyclerViewSubscribers.setAdapter(subscribersAdapter);
-        subscribersAdapter.setClickListener(this);
+        if (savedInstanceState == null) {
+            viewFragment = inflater.inflate(R.layout.fragment_subscribers_list, container, false);
+            swipeLayout = (SwipeRefreshLayout) viewFragment.findViewById(R.id.swipe_layout);
+            swipeLayout.setOnRefreshListener(this);
+            RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.recycler_view_subscribers);
+            recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
+            recyclerViewSubscribers.setAdapter(subscribersAdapter);
+            subscribersAdapter.setClickListener(this);
+        }else{
+            Utils.debugLog(savedInstanceState.toString());
+        }
         return viewFragment;
     }
 
@@ -107,7 +115,6 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
 
     @Override
     public void onRefresh() {
-        Utils.debugLog("onREFRESHING");
         loadSubscribers();
     }
 

--- a/app/src/main/res/layout/fragment_subscribers_detail.xml
+++ b/app/src/main/res/layout/fragment_subscribers_detail.xml
@@ -152,7 +152,6 @@
         android:id="@+id/list_repositories"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_margin="@dimen/margin_common"
         android:scrollbars="vertical" />
 
 

--- a/app/src/main/res/layout/row_repository.xml
+++ b/app/src/main/res/layout/row_repository.xml
@@ -3,9 +3,7 @@
     android:id="@+id/card_view_repository"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/layout_margin_row_card"
-    android:layout_marginRight="@dimen/layout_margin_row_card"
-    android:layout_marginTop="@dimen/layout_margin_row_card"
+    android:layout_margin="@dimen/layout_margin_row_card"
     card_view:cardCornerRadius="@dimen/card_corner_radius">
 
     <RelativeLayout

--- a/app/src/main/res/layout/row_subscriber.xml
+++ b/app/src/main/res/layout/row_subscriber.xml
@@ -4,9 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:id="@+id/card_view"
-    android:layout_marginTop="@dimen/layout_margin_row_card"
-    android:layout_marginLeft="@dimen/layout_margin_row_card"
-    android:layout_marginRight="@dimen/layout_margin_row_card"
+    android:layout_margin="@dimen/layout_margin_row_card"
     card_view:cardCornerRadius="@dimen/card_corner_radius">
 
     <RelativeLayout


### PR DESCRIPTION
- Added support to save instance state in SubscriberList Fragment to avoid recreate the fields/attributes on configuration change like device rotation.
- Added support to save instance state in Splash activity to avoid duplicate fragment.

The next trello cards are solved:
- https://trello.com/c/tV40lonJ/16-crash-rotating-the-device
- https://trello.com/c/5BuUwqeu/11-rotating-the-device-the-splash-fragment-is-added-once-again
