### PR TITLE
Solved Crash from api request answer

### DIFF
--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Constants.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public final static String MESSAGE_FAILED_SERVICE = "The sevice is not available";
 
     public static final long SPLASH_DELAY = 3000;
+    public static final String EXCEPTION_ERROR = "Exception";
 
     public final static class SplashLogoAnimation {
         public final static long START_DELAY = 200;

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Debug.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Debug.java
@@ -3,22 +3,52 @@ package com.github.globant.githubsubscribers.commons.utils;
 import android.util.Log;
 
 /**
+ * Debug class to manage all log types to print messages on debug process
+ *
  * @author edwin.cobos
  * @since 06/09/2016
  */
 public class Debug {
+
+    /**
+     * Send an INFO log message.
+     *
+     * @param msg
+     */
     public static void i(String msg) {
         if (Constants.DEBUG_LOGS) {
             Log.i(Constants.DEBUG_PREFIX, msg);
         }
     }
 
+    /**
+     * Send an ERROR log message.
+     *
+     * @param msg
+     */
     public static void e(String msg) {
         if (Constants.DEBUG_LOGS) {
             Log.e(Constants.DEBUG_PREFIX, msg);
         }
     }
 
+    /**
+     * Send a ERROR log message and log the exception.
+     *
+     * @param msg
+     * @param tr
+     */
+    public static void e(String msg, Throwable tr) {
+        if (Constants.DEBUG_LOGS) {
+            Log.e(Constants.DEBUG_PREFIX, msg, tr);
+        }
+    }
+
+    /**
+     * Send a DEBUG log message.
+     *
+     * @param msg
+     */
     public static void d(String msg) {
         if (Constants.DEBUG_LOGS) {
             Log.d(Constants.DEBUG_PREFIX, msg);

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Debug.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Debug.java
@@ -1,0 +1,27 @@
+package com.github.globant.githubsubscribers.commons.utils;
+
+import android.util.Log;
+
+/**
+ * @author edwin.cobos
+ * @since 06/09/2016
+ */
+public class Debug {
+    public static void i(String msg) {
+        if (Constants.DEBUG_LOGS) {
+            Log.i(Constants.DEBUG_PREFIX, msg);
+        }
+    }
+
+    public static void e(String msg) {
+        if (Constants.DEBUG_LOGS) {
+            Log.e(Constants.DEBUG_PREFIX, msg);
+        }
+    }
+
+    public static void d(String msg) {
+        if (Constants.DEBUG_LOGS) {
+            Log.d(Constants.DEBUG_PREFIX, msg);
+        }
+    }
+}

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
@@ -32,7 +32,7 @@ public class ErrorMessagesHelper {
                 messageId = R.string.api_client_error_bad_answer;
                 break;
             case REQUEST_CANCELLED:
-                messageId = R.string.api_client_error_request_cancel;
+                messageId = R.string.api_client_error_request_cancelled;
                 break;
             case NO_CONNECTION:
             default:

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
@@ -1,0 +1,44 @@
+package com.github.globant.githubsubscribers.commons.utils;
+
+import com.github.globant.githubsubscribers.R;
+
+/**
+ * Helper class to manage error messages
+ *
+ * @author edwin.cobos
+ * @since 05/09/2016
+ */
+public class ErrorMessagesHelper {
+
+    /**
+     * List of types errors
+     */
+    public enum TypeError {
+        NO_CONNECTION,
+        BAD_ANSWER,
+        REQUEST_CANCELLED
+    }
+
+    /**
+     * Static method to get a error message according with the type error
+     *
+     * @param error
+     * @return
+     */
+    public static int getMessage(TypeError error) {
+        int messageId;
+        switch (error) {
+            case BAD_ANSWER:
+                messageId = R.string.api_client_error;
+                break;
+            case REQUEST_CANCELLED:
+                messageId = -1;
+                break;
+            case NO_CONNECTION:
+            default:
+                messageId = R.string.api_client_error;
+                break;
+        }
+        return messageId;
+    }
+}

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/ErrorMessagesHelper.java
@@ -29,14 +29,14 @@ public class ErrorMessagesHelper {
         int messageId;
         switch (error) {
             case BAD_ANSWER:
-                messageId = R.string.api_client_error;
+                messageId = R.string.api_client_error_bad_answer;
                 break;
             case REQUEST_CANCELLED:
-                messageId = -1;
+                messageId = R.string.api_client_error_request_cancel;
                 break;
             case NO_CONNECTION:
             default:
-                messageId = R.string.api_client_error;
+                messageId = R.string.api_client_error_no_connection;
                 break;
         }
         return messageId;

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
@@ -14,12 +14,6 @@ import android.util.Log;
  */
 public class Utils {
 
-    public static void debugLog(String msg) {
-        if (Constants.DEBUG_LOGS) {
-            Log.i(Constants.DEBUG_PREFIX, msg);
-        }
-    }
-
     public static void openLinkInBrowser(Context context, String url) {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse(url));

--- a/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/commons/utils/Utils.java
@@ -3,6 +3,7 @@ package com.github.globant.githubsubscribers.commons.utils;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 /**
@@ -25,4 +26,9 @@ public class Utils {
         context.startActivity(intent);
     }
 
+    public static void hideBar(AppCompatActivity activity) {
+        if(activity.getSupportActionBar() != null) {
+            activity.getSupportActionBar().hide();
+        }
+    }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
@@ -8,6 +8,7 @@ import android.widget.ImageView;
 
 import com.github.globant.githubsubscribers.R;
 import com.github.globant.githubsubscribers.commons.utils.Constants;
+import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.main.MainActivity;
 
 /**
@@ -23,6 +24,7 @@ public class SplashActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
+        Utils.hideBar(this);
         if (savedInstanceState == null) {
             startAnimation();
             startTimer();

--- a/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/splash/SplashActivity.java
@@ -23,8 +23,10 @@ public class SplashActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
-        startAnimation();
-        startTimer();
+        if (savedInstanceState == null) {
+            startAnimation();
+            startTimer();
+        }
     }
 
     /**

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractor.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractor.java
@@ -2,6 +2,7 @@ package com.github.globant.githubsubscribers.subscribersdetail.interactor;
 
 import com.github.globant.githubsubscribers.commons.models.Repository;
 import com.github.globant.githubsubscribers.commons.models.User;
+import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 
 import java.util.List;
 
@@ -14,13 +15,19 @@ import java.util.List;
 public interface SubscriberDetailInteractor {
     interface OnFinishedListener {
         void onFinishedUser(User userItem);
-        void onFailureUser(String errorMessage);
+
+        void onFailureUser(String errorMessage, ErrorMessagesHelper.TypeError type);
 
         void onFinishedRepository(List<Repository> repositoryList);
-        void onFailureRepository(String errorMessage);
+
+        void onFailureRepository(String errorMessage, ErrorMessagesHelper.TypeError type);
     }
 
     void getUserData(String userName, OnFinishedListener listener);
 
     void getUserRepositoryData(String userName, OnFinishedListener listener);
+
+    void onCancelRequestUser();
+
+    void onCancelRequestRepository();
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
@@ -3,7 +3,9 @@ package com.github.globant.githubsubscribers.subscribersdetail.interactor;
 import com.github.globant.githubsubscribers.commons.models.Repository;
 import com.github.globant.githubsubscribers.commons.models.User;
 import com.github.globant.githubsubscribers.commons.utils.ApiClientGithub;
+import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 
+import java.io.IOException;
 import java.util.List;
 
 import retrofit2.Call;
@@ -18,37 +20,78 @@ import retrofit2.Response;
  * @since 30/08/2016
  */
 public class SubscriberDetailInteractorImpl implements SubscriberDetailInteractor {
+    private Call<User> callUser;
+    private Call<List<Repository>> callRepositories;
+
     @Override
     public void getUserData(String userName, final OnFinishedListener listener) {
-        Call<User> call = ApiClientGithub.getApiService().getSubscriberUser(userName);
-        call.enqueue(new Callback<User>() {
+        callUser = ApiClientGithub.getApiService().getSubscriberUser(userName);
+        callUser.enqueue(new Callback<User>() {
             @Override
             public void onResponse(Call<User> call, Response<User> response) {
-                User userItem = response.body();
-                listener.onFinishedUser(userItem);
+                if (response.isSuccessful()) {
+                    User userItem = response.body();
+                    listener.onFinishedUser(userItem);
+                } else {
+                    try {
+                        listener.onFailureUser(response.errorBody().string(), ErrorMessagesHelper.TypeError.BAD_ANSWER);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
             }
 
             @Override
             public void onFailure(Call<User> call, Throwable t) {
-                listener.onFailureUser(t.getMessage());
+                if (call.isCanceled()) {
+                    listener.onFailureUser(t.getMessage(), ErrorMessagesHelper.TypeError.REQUEST_CANCELLED);
+                } else {
+                    listener.onFailureUser(t.getMessage(), ErrorMessagesHelper.TypeError.NO_CONNECTION);
+                }
             }
         });
     }
 
     @Override
     public void getUserRepositoryData(String userName, final OnFinishedListener listener) {
-        Call<List<Repository>> call = ApiClientGithub.getApiService().getUserRepositories(userName);
-        call.enqueue(new Callback<List<Repository>>() {
+        callRepositories = ApiClientGithub.getApiService().getUserRepositories(userName);
+        callRepositories.enqueue(new Callback<List<Repository>>() {
             @Override
             public void onResponse(Call<List<Repository>> call, Response<List<Repository>> response) {
-                List<Repository> repositoryList = response.body();
-                listener.onFinishedRepository(repositoryList);
+                if (response.isSuccessful()) {
+                    List<Repository> repositoryList = response.body();
+                    listener.onFinishedRepository(repositoryList);
+                } else {
+                    try {
+                        listener.onFailureRepository(response.errorBody().string(), ErrorMessagesHelper.TypeError.BAD_ANSWER);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
             }
 
             @Override
             public void onFailure(Call<List<Repository>> call, Throwable t) {
-                listener.onFailureRepository(t.getMessage());
+                if (call.isCanceled()) {
+                    listener.onFailureRepository(t.getMessage(), ErrorMessagesHelper.TypeError.REQUEST_CANCELLED);
+                } else {
+                    listener.onFailureRepository(t.getMessage(), ErrorMessagesHelper.TypeError.NO_CONNECTION);
+                }
             }
         });
+    }
+
+    @Override
+    public void onCancelRequestUser() {
+        if (callUser.isExecuted()) {
+            callUser.cancel();
+        }
+    }
+
+    @Override
+    public void onCancelRequestRepository() {
+        if (callRepositories.isExecuted()) {
+            callRepositories.cancel();
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/interactor/SubscriberDetailInteractorImpl.java
@@ -3,6 +3,8 @@ package com.github.globant.githubsubscribers.subscribersdetail.interactor;
 import com.github.globant.githubsubscribers.commons.models.Repository;
 import com.github.globant.githubsubscribers.commons.models.User;
 import com.github.globant.githubsubscribers.commons.utils.ApiClientGithub;
+import com.github.globant.githubsubscribers.commons.utils.Constants;
+import com.github.globant.githubsubscribers.commons.utils.Debug;
 import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 
 import java.io.IOException;
@@ -36,7 +38,7 @@ public class SubscriberDetailInteractorImpl implements SubscriberDetailInteracto
                     try {
                         listener.onFailureUser(response.errorBody().string(), ErrorMessagesHelper.TypeError.BAD_ANSWER);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        Debug.e(Constants.EXCEPTION_ERROR, e);
                     }
                 }
             }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
@@ -21,10 +21,12 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
 
     private SubscriberDetailView view;
     private SubscriberDetailInteractor interactor;
+    private final String TAG;
 
     public SubscriberDetailPresenterImpl(SubscriberDetailView view) {
         this.view = view;
         this.interactor = new SubscriberDetailInteractorImpl();
+        TAG = this.getClass().getSimpleName();
     }
 
     public void onFinishedUser(User userItem) {
@@ -51,7 +53,7 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
         if (messageId > 0 && view != null) {
             view.showUserError(messageId);
         }
-        Debug.e(this.getClass().getEnclosingMethod().getName() + ": " + errorMessage);
+        Debug.e(TAG + ": s" + this.getClass().getEnclosingMethod().getName() + ": " + errorMessage);
     }
 
     @Override

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
@@ -2,7 +2,8 @@ package com.github.globant.githubsubscribers.subscribersdetail.presenter;
 
 import com.github.globant.githubsubscribers.commons.models.Repository;
 import com.github.globant.githubsubscribers.commons.models.User;
-import com.github.globant.githubsubscribers.commons.utils.Utils;
+import com.github.globant.githubsubscribers.commons.utils.Debug;
+import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 import com.github.globant.githubsubscribers.subscribersdetail.interactor.SubscriberDetailInteractor;
 import com.github.globant.githubsubscribers.subscribersdetail.interactor.SubscriberDetailInteractorImpl;
 import com.github.globant.githubsubscribers.subscribersdetail.view.SubscriberDetailView;
@@ -31,23 +32,33 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
     }
 
     @Override
-    public void onFailureUser(String errorMessage) {
-        view.showUserError();
-    }
-
-    @Override
     public void onFinishedRepository(List<Repository> repositoryList) {
         view.showSubscriberUserRepositories(repositoryList);
     }
 
     @Override
-    public void onFailureRepository(String errorMessage) {
-        view.showRepositoryError();
+    public void onFailureUser(String errorMessage, ErrorMessagesHelper.TypeError type) {
+        int messageId = ErrorMessagesHelper.getMessage(type);
+        if (messageId > 0 && view != null) {
+            view.showUserError(messageId);
+        }
+        Debug.e(this.getClass().getEnclosingMethod().getName()+": "+errorMessage);
+    }
+
+    @Override
+    public void onFailureRepository(String errorMessage, ErrorMessagesHelper.TypeError type) {
+        int messageId = ErrorMessagesHelper.getMessage(type);
+        if (messageId > 0 && view != null) {
+            view.showUserError(messageId);
+        }
+        Debug.e(this.getClass().getEnclosingMethod().getName()+": "+errorMessage);
     }
 
     @Override
     public void onDestroy() {
         view = null;
+        interactor.onCancelRequestUser();
+        interactor.onCancelRequestRepository();
     }
 
     @Override

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/presenter/SubscriberDetailPresenterImpl.java
@@ -42,7 +42,7 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
         if (messageId > 0 && view != null) {
             view.showUserError(messageId);
         }
-        Debug.e(this.getClass().getEnclosingMethod().getName()+": "+errorMessage);
+        Debug.e(this.getClass().getEnclosingMethod().getName() + ": " + errorMessage);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class SubscriberDetailPresenterImpl implements SubscriberDetailPresenter,
         if (messageId > 0 && view != null) {
             view.showUserError(messageId);
         }
-        Debug.e(this.getClass().getEnclosingMethod().getName()+": "+errorMessage);
+        Debug.e(this.getClass().getEnclosingMethod().getName() + ": " + errorMessage);
     }
 
     @Override

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailFragment.java
@@ -42,6 +42,7 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     private TextView profileReposCounter;
     private String profileHtmlUrl;
     private RepositoryAdapter repositoriesAdapter;
+    private View viewFragment;
 
     private SubscriberDetailPresenter presenter;
 
@@ -49,7 +50,11 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         loadArgs();
-        repositoriesAdapter = new RepositoryAdapter();
+        if (savedInstanceState == null) {
+            setRetainInstance(true);
+            repositoriesAdapter = new RepositoryAdapter();
+            presenter = new SubscriberDetailPresenterImpl(this);
+        }
     }
 
     public static SubscriberDetailFragment newInstance(String userName) {
@@ -69,23 +74,24 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
-        presenter = new SubscriberDetailPresenterImpl(this);
+        if (savedInstanceState == null) {
+            viewFragment = inflater.inflate(R.layout.fragment_subscribers_detail, container, false);
 
-        profileImage = (ImageView) viewFragment.findViewById(R.id.img_avatar_subscriber_detail);
-        profileFullName = (TextView) viewFragment.findViewById(R.id.txt_full_name_subscriber_detail);
-        profileFullName.setOnClickListener(this);
-        profileUserName = (TextView) viewFragment.findViewById(R.id.txt_user_name_subscriber_detail);
-        profileCompany = (TextView) viewFragment.findViewById(R.id.txt_company_subscriber_detail);
-        profileLocation = (TextView) viewFragment.findViewById(R.id.txt_location_subscriber_detail);
-        profileFollowingCounter = (TextView) viewFragment.findViewById(R.id.txt_following_counter_subscriber_detail);
-        profileFollowersCounter = (TextView) viewFragment.findViewById(R.id.txt_followers_counter_subscriber_detail);
-        profileReposCounter = (TextView) viewFragment.findViewById(R.id.txt_repos_counter_subscriber_detail);
+            profileImage = (ImageView) viewFragment.findViewById(R.id.img_avatar_subscriber_detail);
+            profileFullName = (TextView) viewFragment.findViewById(R.id.txt_full_name_subscriber_detail);
+            profileFullName.setOnClickListener(this);
+            profileUserName = (TextView) viewFragment.findViewById(R.id.txt_user_name_subscriber_detail);
+            profileCompany = (TextView) viewFragment.findViewById(R.id.txt_company_subscriber_detail);
+            profileLocation = (TextView) viewFragment.findViewById(R.id.txt_location_subscriber_detail);
+            profileFollowingCounter = (TextView) viewFragment.findViewById(R.id.txt_following_counter_subscriber_detail);
+            profileFollowersCounter = (TextView) viewFragment.findViewById(R.id.txt_followers_counter_subscriber_detail);
+            profileReposCounter = (TextView) viewFragment.findViewById(R.id.txt_repos_counter_subscriber_detail);
 
-        RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.list_repositories);
-        recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
-        recyclerViewSubscribers.setAdapter(repositoriesAdapter);
-        repositoriesAdapter.setClickListener(this);
+            RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.list_repositories);
+            recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
+            recyclerViewSubscribers.setAdapter(repositoriesAdapter);
+            repositoriesAdapter.setClickListener(this);
+        }
         return viewFragment;
     }
 
@@ -102,15 +108,8 @@ public class SubscriberDetailFragment extends Fragment implements SubscriberDeta
     }
 
     @Override
-    public void showUserError() {
-        //TODO Manage error messages
-        Toast.makeText(getContext(), R.string.api_client_error, Toast.LENGTH_LONG).show();
-    }
-
-    @Override
-    public void showRepositoryError() {
-        //TODO Manage error messages
-        Toast.makeText(getContext(), R.string.api_client_error, Toast.LENGTH_LONG).show();
+    public void showUserError(int messageId) {
+        Toast.makeText(getContext(), messageId, Toast.LENGTH_LONG).show();
     }
 
     public void showSubscriberDetails(User userInfo) {

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailView.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscribersdetail/view/SubscriberDetailView.java
@@ -18,7 +18,5 @@ public interface SubscriberDetailView {
 
     void showSubscriberUserRepositories(List<Repository> repositoryList);
 
-    void showUserError();
-
-    void showRepositoryError();
+    void showUserError(int messageId);
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractor.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractor.java
@@ -1,6 +1,7 @@
 package com.github.globant.githubsubscribers.subscriberslist.interactor;
 
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
+import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 
 import java.util.List;
 
@@ -14,9 +15,12 @@ import java.util.List;
 public interface SubscribersListInteractor {
     interface OnFinishedListener {
         void onResponse(List<Subscriber> listItems);
-        void onFailure(String errorMessage);
+
+        void onFailure(String errorMessage, ErrorMessagesHelper.TypeError type);
     }
 
     void getSubscribersDataList(OnFinishedListener listener);
+
+    void onCancelRequest();
 
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
@@ -2,6 +2,8 @@ package com.github.globant.githubsubscribers.subscriberslist.interactor;
 
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
 import com.github.globant.githubsubscribers.commons.utils.ApiClientGithub;
+import com.github.globant.githubsubscribers.commons.utils.Constants;
+import com.github.globant.githubsubscribers.commons.utils.Debug;
 import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
 
 import java.io.IOException;
@@ -35,7 +37,7 @@ public class SubscribersListInteractorImpl implements SubscribersListInteractor 
                     try {
                         listener.onFailure(response.errorBody().string(), ErrorMessagesHelper.TypeError.BAD_ANSWER);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        Debug.e(Constants.EXCEPTION_ERROR, e);
                     }
                 }
             }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/interactor/SubscribersListInteractorImpl.java
@@ -3,7 +3,6 @@ package com.github.globant.githubsubscribers.subscriberslist.interactor;
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
 import com.github.globant.githubsubscribers.commons.utils.ApiClientGithub;
 import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
-import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractor;
 
 import java.io.IOException;
 import java.util.List;
@@ -53,6 +52,8 @@ public class SubscribersListInteractorImpl implements SubscribersListInteractor 
 
     @Override
     public void onCancelRequest() {
-        call.cancel();
+        if (call.isExecuted()) {
+            call.cancel();
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
@@ -1,8 +1,8 @@
 package com.github.globant.githubsubscribers.subscriberslist.presenter;
 
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
+import com.github.globant.githubsubscribers.commons.utils.Debug;
 import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
-import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractor;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractorImpl;
 import com.github.globant.githubsubscribers.subscriberslist.view.SubscribersListView;
@@ -46,10 +46,10 @@ public class SubscribersListPresenterImpl implements SubscribersListPresenter, S
 
     @Override
     public void onFailure(String errorMessage, ErrorMessagesHelper.TypeError type) {
-        Utils.debugLog(errorMessage);
         int messageId = ErrorMessagesHelper.getMessage(type);
         if (messageId > 0 && view != null) {
             view.showSubscribersError(messageId);
         }
+        Debug.e(this.getClass().getEnclosingMethod().getName() + ": " + errorMessage);
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/presenter/SubscribersListPresenterImpl.java
@@ -1,6 +1,8 @@
 package com.github.globant.githubsubscribers.subscriberslist.presenter;
 
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
+import com.github.globant.githubsubscribers.commons.utils.ErrorMessagesHelper;
+import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractor;
 import com.github.globant.githubsubscribers.subscriberslist.interactor.SubscribersListInteractorImpl;
 import com.github.globant.githubsubscribers.subscriberslist.view.SubscribersListView;
@@ -27,6 +29,7 @@ public class SubscribersListPresenterImpl implements SubscribersListPresenter, S
     @Override
     public void onDestroy() {
         view = null;
+        interactor.onCancelRequest();
     }
 
     @Override
@@ -36,12 +39,17 @@ public class SubscribersListPresenterImpl implements SubscribersListPresenter, S
 
     @Override
     public void onResponse(List<Subscriber> listItems) {
-        view.showSubscribersList(listItems);
+        if (view != null) {
+            view.showSubscribersList(listItems);
+        }
     }
 
     @Override
-    public void onFailure(String errorMessage) {
-        //TODO: Manage message errors
-        view.showSubscribersError();
+    public void onFailure(String errorMessage, ErrorMessagesHelper.TypeError type) {
+        Utils.debugLog(errorMessage);
+        int messageId = ErrorMessagesHelper.getMessage(type);
+        if (messageId > 0 && view != null) {
+            view.showSubscribersError(messageId);
+        }
     }
 }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersAdapter.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersAdapter.java
@@ -78,10 +78,6 @@ public class SubscribersAdapter extends RecyclerView.Adapter<SubscribersAdapter.
             Picasso.with(image.getContext()).load(item.getAvataUrl()).into(image);
         }
 
-        public String getUserName() {
-            return text.getText().toString();
-        }
-
         @Override
         public void onClick(View view) {
             if (clickListener != null) {

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 
 import com.github.globant.githubsubscribers.R;
 import com.github.globant.githubsubscribers.commons.models.Subscriber;
+import com.github.globant.githubsubscribers.commons.utils.Debug;
 import com.github.globant.githubsubscribers.commons.utils.Utils;
 import com.github.globant.githubsubscribers.subscriberslist.presenter.SubscribersListPresenter;
 import com.github.globant.githubsubscribers.subscriberslist.presenter.SubscribersListPresenterImpl;
@@ -57,7 +58,7 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
             recyclerViewSubscribers.setAdapter(subscribersAdapter);
             subscribersAdapter.setClickListener(this);
         }else{
-            Utils.debugLog(savedInstanceState.toString());
+            Debug.i(savedInstanceState.toString());
         }
         return viewFragment;
     }

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
@@ -31,26 +31,36 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
     private SubscribersListPresenter presenter;
     private SubscribersAdapter subscribersAdapter;
     private SwipeRefreshLayout swipeLayout;
+    private View viewFragment;
 
     private OnFragmentInteractionListener mListener;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        subscribersAdapter = new SubscribersAdapter();
+        if (savedInstanceState == null) {
+            setRetainInstance(true);
+            subscribersAdapter = new SubscribersAdapter();
+            presenter = new SubscribersListPresenterImpl(this);
+        }
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View viewFragment = inflater.inflate(R.layout.fragment_subscribers_list, container, false);
-        swipeLayout = (SwipeRefreshLayout) viewFragment.findViewById(R.id.swipe_layout);
-        swipeLayout.setOnRefreshListener(this);
-        presenter = new SubscribersListPresenterImpl(this);
-        RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.recycler_view_subscribers);
-        recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
-        recyclerViewSubscribers.setAdapter(subscribersAdapter);
-        subscribersAdapter.setClickListener(this);
+        if (savedInstanceState == null) {
+            viewFragment = inflater.inflate(R.layout.fragment_subscribers_list, container, false);
+            swipeLayout = (SwipeRefreshLayout) viewFragment.findViewById(R.id.swipe_layout);
+            swipeLayout.setOnRefreshListener(this);
+            RecyclerView recyclerViewSubscribers = (RecyclerView) viewFragment.findViewById(R.id.recycler_view_subscribers);
+            recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
+            recyclerViewSubscribers.setAdapter(subscribersAdapter);
+            subscribersAdapter.setClickListener(this);
+            Utils.debugLog("onCREATEView 00");
+        }else{
+            Utils.debugLog(savedInstanceState.toString());
+        }
+        Utils.debugLog("onCREATEView");
         return viewFragment;
     }
 
@@ -90,6 +100,7 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
 
     @Override
     public void onDestroy() {
+        Utils.debugLog("onDESTROY");
         super.onDestroy();
         presenter.onDestroy();
     }
@@ -101,8 +112,8 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
     }
 
     @Override
-    public void showSubscribersError() {
-        Toast.makeText(getContext(), R.string.api_client_error, Toast.LENGTH_LONG).show();
+    public void showSubscribersError(int messageId) {
+        Toast.makeText(getContext(), messageId, Toast.LENGTH_LONG).show();
     }
 
     @Override

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListFragment.java
@@ -56,11 +56,9 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
             recyclerViewSubscribers.setLayoutManager(new LinearLayoutManager(getActivity()));
             recyclerViewSubscribers.setAdapter(subscribersAdapter);
             subscribersAdapter.setClickListener(this);
-            Utils.debugLog("onCREATEView 00");
         }else{
             Utils.debugLog(savedInstanceState.toString());
         }
-        Utils.debugLog("onCREATEView");
         return viewFragment;
     }
 
@@ -100,7 +98,6 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
 
     @Override
     public void onDestroy() {
-        Utils.debugLog("onDESTROY");
         super.onDestroy();
         presenter.onDestroy();
     }
@@ -118,7 +115,6 @@ public class SubscribersListFragment extends Fragment implements SubscribersList
 
     @Override
     public void onRefresh() {
-        Utils.debugLog("onREFRESHING");
         loadSubscribers();
     }
 

--- a/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListView.java
+++ b/app/src/main/java/com/github/globant/githubsubscribers/subscriberslist/view/SubscribersListView.java
@@ -14,6 +14,6 @@ public interface SubscribersListView {
 
     void showSubscribersList(List<Subscriber> subscriberList);
 
-    void showSubscribersError();
+    void showSubscribersError(int messageId);
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,9 @@
 <resources>
     <string name="app_name">Github Subscribers</string>
     <string name="splash_title">GITHUB SUBSCRIBERS</string>
-    <string name="api_client_error_no_connection">Connection problems</string>
-    <string name="api_client_error_bad_answer">Server not responding</string>
-    <string name="api_client_error_request_cancel">Request cancel</string>
+    <string name="api_client_error_no_connection">We are having connections issues, please try again later</string>
+    <string name="api_client_error_bad_answer">Sorry, we are having issues. We are working so hard to solve this.</string>
+    <string name="api_client_error_request_cancelled">The request was cancelled</string>
     <string name="followers">Followers:</string>
     <string name="following">Following:</string>
     <string name="repositories">Repositories:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,9 @@
 <resources>
     <string name="app_name">Github Subscribers</string>
     <string name="splash_title">GITHUB SUBSCRIBERS</string>
-    <string name="api_client_error">Connection problems</string>
+    <string name="api_client_error_no_connection">Connection problems</string>
+    <string name="api_client_error_bad_answer">Server not responding</string>
+    <string name="api_client_error_request_cancel">Request cancel</string>
     <string name="followers">Followers:</string>
     <string name="following">Following:</string>
     <string name="repositories">Repositories:</string>


### PR DESCRIPTION
- Added Support to manage the error messages from API Request.
- Added Debug class to manage all debug messages of this App
- Changed Debug logs in SubscribersListFragment class to the new class for debug messages
- Removed debugLog method from Utils class. Replaced by Debug class methods.
- Added debug message in onFailure method to show ErrorMessages.
- Added validation in onCancelRequest method in SubscribersListInteractorImpl class and SubscriberDetailInteractor class

> Note that this branch was merged with `Resolution-Crash` branch which was merged with `master` branch

The below trello cards are solved:
https://trello.com/c/phV19aZo/18-crash-when-github-service-send-bad-answer
